### PR TITLE
Fix npm workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - run: npm ci
+      - run: npm install
       - run: npm test
 
   publish-npm:
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/
-      - run: npm ci
+      - run: npm install
       - run: npm run build
       - run: npm publish
         env:


### PR DESCRIPTION
## Summary
- update publishing workflow to use `npm install` instead of `npm ci`

## Testing
- `npm install`
- `npm test`
- `act` *(fails: couldn't connect to Docker)*

------
https://chatgpt.com/codex/tasks/task_e_685a2cb06f18832bb7f07f8a08d7ec6e